### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -4,6 +4,7 @@ on:
     types: [opened, synchronize, reopened]
 permissions:
   contents: read
+  actions: write
 env:
   NEXT_PUBLIC_TINA_CLIENT_ID: ${{ secrets.NEXT_PUBLIC_TINA_CLIENT_ID }}
   TINA_TOKEN: ${{ secrets.TINA_TOKEN }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -2,6 +2,8 @@ name: Build Pull request
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+permissions:
+  contents: read
 env:
   NEXT_PUBLIC_TINA_CLIENT_ID: ${{ secrets.NEXT_PUBLIC_TINA_CLIENT_ID }}
   TINA_TOKEN: ${{ secrets.TINA_TOKEN }}


### PR DESCRIPTION
Potential fix for [https://github.com/Volcar144/BetterBlog/security/code-scanning/2](https://github.com/Volcar144/BetterBlog/security/code-scanning/2)

To fix the problem, we should explicitly specify the permissions to restrict the GITHUB_TOKEN to the minimum required level for jobs in this workflow. Since this is a build workflow (install dependencies, build the project) and does not interact with pull requests, contents, or any other repository resource in a write capacity, the best minimal starting point is to set `permissions: contents: read` at the top level (just below the workflow `name` and `on` keys, before `env` or `jobs`) so that it applies to all jobs in the workflow.

No imports, methods, or further code definitions are needed since this is handled purely at the YAML configuration level. Only a single block needs editing: insert a `permissions:` block with `contents: read` beneath the `name` and `on` block in `.github/workflows/pr-open.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * Adjusted CI workflow permissions to allow secure repository read access and to enable workflow write actions, improving reliability of automated checks.
  * Internal maintenance only; no changes to features, performance, or UI—end-users should see no difference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->