### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-dependabot-pr.yml
+++ b/.github/workflows/update-dependabot-pr.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - dependabot/npm_and_yarn/**
 
+permissions:
+  contents: write
+
 jobs:
   update-tinacms:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-dependabot-pr.yml
+++ b/.github/workflows/update-dependabot-pr.yml
@@ -5,10 +5,13 @@ on:
       - dependabot/npm_and_yarn/**
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   update-tinacms:
+    permissions:
+      contents: write
+      actions: write
     runs-on: ubuntu-latest
     steps:
       # Clone repo

--- a/.github/workflows/update-dependabot-pr.yml
+++ b/.github/workflows/update-dependabot-pr.yml
@@ -16,9 +16,9 @@ jobs:
     steps:
       # Clone repo
       - name: Check out repo to update
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
       # Install deps, update Tina packages, update schema


### PR DESCRIPTION
Potential fix for [https://github.com/Volcar144/BetterBlog/security/code-scanning/1](https://github.com/Volcar144/BetterBlog/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow YAML file. This should be at the workflow root (before `jobs:`), or scoped to the specific job as needed. As this workflow uses an action that needs to commit to the repo (`EndBug/add-and-commit`), it requires `contents: write` permission. No other special scopes (like `pull-requests: write`) are necessary since PR interactions are not present. Thus, as a minimal fix, add:

```yaml
permissions:
  contents: write
```

This should be placed after the `on:` block (so, immediately before `jobs:`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to allow automated dependency update PRs to write repository contents.
  * No functional changes to the product, build, or runtime behavior.
  * Improves reliability of maintenance automation and clarifies least-privilege settings.
  * End users will not see any interface or feature changes.
  * No action required for users or admins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->